### PR TITLE
Add support for all public post types and hide fields if comments not op...

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -13,7 +13,7 @@ Add custom notes before or after the comment form.
 
 == Description ==
 
-Add custom notes before or after the comment form.
+Add custom notes before or after the comment form on a post by post basis.
 
 
 == Installation ==


### PR DESCRIPTION
Adds a get_post_types() function that retrieves a list of public post types and also eliminates those that do not support comments.

I also added a single line of JS to hide / show the meta box options if an item's comments are open/closed.

Related to #1.
